### PR TITLE
Stream notifier

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,20 +1,26 @@
 PODS:
+  - connectivity_plus (0.0.1):
+    - Flutter
   - Flutter (1.0.0)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
 
 DEPENDENCIES:
+  - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
   - Flutter (from `Flutter`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
 
 EXTERNAL SOURCES:
+  connectivity_plus:
+    :path: ".symlinks/plugins/connectivity_plus/ios"
   Flutter:
     :path: Flutter
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
 
 SPEC CHECKSUMS:
+  connectivity_plus: 2a701ffec2c0ae28a48cf7540e279787e77c447d
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
 

--- a/lib/StreamNotifier/connectivity_plus_notifier.dart
+++ b/lib/StreamNotifier/connectivity_plus_notifier.dart
@@ -1,0 +1,90 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+part 'connectivity_plus_notifier.g.dart';
+
+/// ネットワーク接続状態を表すenum
+enum NetworkStatus {
+  /// オンライン状態（WiFi接続）
+  wifiOnline,
+
+  /// オンライン状態（モバイルデータ接続）
+  mobileOnline,
+
+  /// オンライン状態（イーサネット接続）
+  ethernetOnline,
+
+  /// オンライン状態（その他の接続）
+  otherOnline,
+
+  /// オフライン状態
+  offline,
+
+  /// 不明な状態
+  unknown;
+
+  /// オンライン状態かどうかを判定
+  bool get isOnline =>
+      this != NetworkStatus.offline && this != NetworkStatus.unknown;
+
+  /// WiFi接続かどうかを判定
+  bool get isWifi => this == NetworkStatus.wifiOnline;
+
+  /// モバイルデータ接続かどうかを判定
+  bool get isMobile => this == NetworkStatus.mobileOnline;
+}
+
+/// ネットワーク接続状態を監視するStreamNotifier
+@riverpod
+class ConnectivityPlusNotifier extends _$ConnectivityPlusNotifier {
+  @override
+  Stream<NetworkStatus> build() {
+    // 接続状態の変更を監視
+    return Connectivity().onConnectivityChanged.map(
+      _mapConnectivityToNetworkStatus,
+    );
+  }
+
+  /// ConnectivityResultをNetworkStatusにマップ
+  NetworkStatus _mapConnectivityToNetworkStatus(
+    List<ConnectivityResult> results,
+  ) {
+    // 接続状態をrecordにまとめる
+    final connectionInfo = (
+      hasWifi: results.contains(ConnectivityResult.wifi),
+      hasMobile: results.contains(ConnectivityResult.mobile),
+      hasEthernet: results.contains(ConnectivityResult.ethernet),
+      hasOther: results.any(
+        (result) => ![
+          ConnectivityResult.wifi,
+          ConnectivityResult.mobile,
+          ConnectivityResult.ethernet,
+          ConnectivityResult.none,
+        ].contains(result),
+      ),
+      hasNone: results.contains(ConnectivityResult.none),
+      isEmpty: results.isEmpty,
+    );
+
+    // パターンマッチングで優先順位に基づいて状態を決定
+    // オフライン状態をチェック
+    if (connectionInfo.hasNone || connectionInfo.isEmpty) {
+      return NetworkStatus.offline;
+    }
+
+    // 優先順位に基づいて接続タイプを決定
+    return switch (true) {
+      _ when connectionInfo.hasWifi => NetworkStatus.wifiOnline,
+      _ when connectionInfo.hasMobile => NetworkStatus.mobileOnline,
+      _ when connectionInfo.hasEthernet => NetworkStatus.ethernetOnline,
+      _ when connectionInfo.hasOther => NetworkStatus.otherOnline,
+      _ => NetworkStatus.unknown,
+    };
+  }
+
+  /// 接続状態を手動でチェック
+  Future<NetworkStatus> checkConnectivity() async {
+    final connectivityResult = await Connectivity().checkConnectivity();
+    return _mapConnectivityToNetworkStatus(connectivityResult);
+  }
+}

--- a/lib/StreamNotifier/connectivity_plus_notifier.g.dart
+++ b/lib/StreamNotifier/connectivity_plus_notifier.g.dart
@@ -1,0 +1,32 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'connectivity_plus_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$connectivityPlusNotifierHash() =>
+    r'cc4cf07967b2f057c02b16a589b0bd94ec302a85';
+
+/// ネットワーク接続状態を監視するStreamNotifier
+///
+/// Copied from [ConnectivityPlusNotifier].
+@ProviderFor(ConnectivityPlusNotifier)
+final connectivityPlusNotifierProvider =
+    AutoDisposeStreamNotifierProvider<
+      ConnectivityPlusNotifier,
+      NetworkStatus
+    >.internal(
+      ConnectivityPlusNotifier.new,
+      name: r'connectivityPlusNotifierProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$connectivityPlusNotifierHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$ConnectivityPlusNotifier = AutoDisposeStreamNotifier<NetworkStatus>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/StreamNotifier/main.dart
+++ b/lib/StreamNotifier/main.dart
@@ -1,0 +1,264 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:udemy_riverpod/StreamNotifier/connectivity_plus_notifier.dart';
+
+void main() {
+  runApp(const ProviderScope(child: MyApp()));
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Connectivity Demo',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+        useMaterial3: true,
+      ),
+      home: const ConnectivityPage(),
+    );
+  }
+}
+
+class ConnectivityPage extends ConsumerWidget {
+  const ConnectivityPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final connectivityAsync = ref.watch(connectivityPlusNotifierProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('ネットワーク接続状態'),
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: () async {
+              final notifier = ref.read(
+                connectivityPlusNotifierProvider.notifier,
+              );
+              final status = await notifier.checkConnectivity();
+              if (context.mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text('現在の状態: ${_getStatusText(status)}')),
+                );
+              }
+            },
+          ),
+        ],
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            // ネットワーク状態表示
+            switch (connectivityAsync) {
+              AsyncData(:final value) => _buildNetworkStatusCard(
+                context,
+                value,
+              ),
+              AsyncError(:final error) => _buildErrorCard(context, error),
+              _ => const CircularProgressIndicator(),
+            },
+
+            const SizedBox(height: 20),
+
+            // オフライン時の警告表示
+            switch (connectivityAsync) {
+              AsyncData(:final value) when value == NetworkStatus.offline =>
+                _buildOfflineWarning(context),
+              _ => const SizedBox.shrink(),
+            },
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildNetworkStatusCard(BuildContext context, NetworkStatus status) {
+    final (icon, color, title, subtitle) = _getStatusInfo(status);
+
+    return Card(
+      elevation: 4,
+      margin: const EdgeInsets.all(16),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 64, color: color),
+            const SizedBox(height: 16),
+            Text(
+              title,
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                color: color,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              subtitle,
+              style: Theme.of(context).textTheme.bodyMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            _buildStatusChips(status),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStatusChips(NetworkStatus status) {
+    return Wrap(
+      spacing: 8,
+      children: [
+        Chip(
+          label: Text('オンライン: ${status.isOnline ? "はい" : "いいえ"}'),
+          backgroundColor: status.isOnline
+              ? Colors.green.shade100
+              : Colors.red.shade100,
+          avatar: Icon(
+            status.isOnline ? Icons.check_circle : Icons.error,
+            color: status.isOnline ? Colors.green : Colors.red,
+            size: 18,
+          ),
+        ),
+        if (status.isWifi)
+          Chip(
+            label: const Text('WiFi接続'),
+            backgroundColor: Colors.blue.shade100,
+            avatar: const Icon(Icons.wifi, color: Colors.blue, size: 18),
+          ),
+        if (status.isMobile)
+          Chip(
+            label: const Text('モバイルデータ'),
+            backgroundColor: Colors.orange.shade100,
+            avatar: const Icon(
+              Icons.signal_cellular_alt,
+              color: Colors.orange,
+              size: 18,
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildOfflineWarning(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.red.shade50,
+        border: Border.all(color: Colors.red.shade300),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.warning_amber, color: Colors.red.shade600),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'オフライン状態',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    color: Colors.red.shade700,
+                  ),
+                ),
+                Text(
+                  'インターネット接続が利用できません。WiFiまたはモバイルデータ接続を確認してください。',
+                  style: TextStyle(color: Colors.red.shade600),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildErrorCard(BuildContext context, Object error) {
+    return Card(
+      elevation: 4,
+      margin: const EdgeInsets.all(16),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.error_outline, size: 64, color: Colors.red),
+            const SizedBox(height: 16),
+            Text(
+              'エラーが発生しました',
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                color: Colors.red,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              error.toString(),
+              style: Theme.of(context).textTheme.bodyMedium,
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  (IconData, Color, String, String) _getStatusInfo(NetworkStatus status) {
+    switch (status) {
+      case NetworkStatus.wifiOnline:
+        return (Icons.wifi, Colors.green, 'WiFi接続中', 'WiFiネットワークに接続されています');
+      case NetworkStatus.mobileOnline:
+        return (
+          Icons.signal_cellular_alt,
+          Colors.orange,
+          'モバイルデータ接続中',
+          'モバイルデータネットワークに接続されています',
+        );
+      case NetworkStatus.ethernetOnline:
+        return (
+          Icons.network_wifi,
+          Colors.blue,
+          'イーサネット接続中',
+          '有線ネットワークに接続されています',
+        );
+      case NetworkStatus.otherOnline:
+        return (
+          Icons.network_check,
+          Colors.purple,
+          'その他のネットワーク接続中',
+          '不明なタイプのネットワークに接続されています',
+        );
+      case NetworkStatus.offline:
+        return (Icons.wifi_off, Colors.red, 'オフライン', 'インターネット接続がありません');
+      case NetworkStatus.unknown:
+        return (Icons.help_outline, Colors.grey, '不明', 'ネットワークの状態を確認できません');
+    }
+  }
+
+  String _getStatusText(NetworkStatus status) {
+    switch (status) {
+      case NetworkStatus.wifiOnline:
+        return 'WiFi接続中';
+      case NetworkStatus.mobileOnline:
+        return 'モバイルデータ接続中';
+      case NetworkStatus.ethernetOnline:
+        return 'イーサネット接続中';
+      case NetworkStatus.otherOnline:
+        return 'その他のネットワーク接続中';
+      case NetworkStatus.offline:
+        return 'オフライン';
+      case NetworkStatus.unknown:
+        return '不明';
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -169,6 +169,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  connectivity_plus:
+    dependency: "direct main"
+    description:
+      name: connectivity_plus
+      sha256: "051849e2bd7c7b3bc5844ea0d096609ddc3a859890ec3a9ac4a65a2620cc1f99"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.4"
+  connectivity_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_plus_platform_interface
+      sha256: "42657c1715d48b167930d5f34d00222ac100475f73d10162ddf43e714932f204"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   convert:
     dependency: transitive
     description:
@@ -233,6 +249,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.11"
   fake_async:
     dependency: transitive
     description:
@@ -472,6 +496,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   package_config:
     dependency: transitive
     description:
@@ -512,6 +544,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "07c8f0b1913bcde1ff0d26e57ace2f3012ccbf2b204e070290dad3bb22797646"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   platform:
     dependency: transitive
     description:
@@ -853,6 +893,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.0"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   tutorial_coach_mark: ^1.3.0
   web_socket_channel: ^3.0.3
   http: ^1.4.0
+  connectivity_plus: ^6.1.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# Background

This pull request introduces a feature to monitor and display network connectivity status using the `connectivity_plus` package. It includes a new notifier class, UI components for displaying connectivity information, and updates to dependencies.

### Connectivity Monitoring Feature:

* **Notifier Implementation**: Added `ConnectivityPlusNotifier` in `connectivity_plus_notifier.dart` to monitor network status as a `Stream` using the `connectivity_plus` package. It includes a `NetworkStatus` enum to represent various connection states and helper methods for status evaluation.
* **Generated Provider Code**: Added `connectivity_plus_notifier.g.dart`, which includes the generated provider code for `ConnectivityPlusNotifier` using the Riverpod generator.

### UI Enhancements:

* **Connectivity Page**: Added a new `ConnectivityPage` in `main.dart` to display the current network status using a `ConsumerWidget`. It includes features like real-time status updates, manual refresh, and visual components (cards, chips, and warnings) to represent the connectivity state.

### Dependency Updates:

* **Added `connectivity_plus`**: Updated `pubspec.yaml` to include the `connectivity_plus` package (version `^6.1.4`) as a new dependency.